### PR TITLE
refactor to expose core recorder functionality separate from the demo UI

### DIFF
--- a/vmsg.js
+++ b/vmsg.js
@@ -264,13 +264,21 @@ class Recorder {
 
   stopRecording() {
     const resultP = new Promise((resolve, reject) => {
-      this.encNode.disconnect();
-      this.encNode.onaudioprocess = null;
+      if (this.encNode) {
+        this.encNode.disconnect();
+        this.encNode.onaudioprocess = null;
+      }
+
       this._resolve = resolve
       this._reject = reject
     });
 
-    this.worker.postMessage({type: "stop", data: null});
+    if (this.worker) {
+      this.worker.postMessage({type: "stop", data: null});
+    } else {
+      return Promise.resolve(this.blob)
+    }
+
     return resultP
   }
 }

--- a/vmsg.js
+++ b/vmsg.js
@@ -302,8 +302,8 @@ class Form {
     this.start = 0;
     Object.seal(this);
 
-    this.drawInit();
     this.recorder.initAudio()
+      .then(() => this.drawInit())
       .then(() => this.recorder.initWorker())
       .then(() => this.drawAll())
       .catch((err) => this.drawError(err));

--- a/vmsg.js
+++ b/vmsg.js
@@ -302,9 +302,9 @@ class Form {
     this.start = 0;
     Object.seal(this);
 
+    this.drawInit();
     this.recorder.initAudio()
       .then(() => this.recorder.initWorker())
-      .then(() => this.drawInit())
       .then(() => this.drawAll())
       .catch((err) => this.drawError(err));
   }

--- a/vmsg.js
+++ b/vmsg.js
@@ -155,8 +155,8 @@ class Recorder {
     this.workerURL = null;
     this.blob = null;
     this.blobURL = null;
-    this._resolve = null;
-    this._reject = null;
+    this.resolve = null;
+    this.reject = null;
     Object.seal(this);
   }
 
@@ -237,13 +237,13 @@ class Recorder {
         case "error":
         case "internal-error":
           console.error("Worker error:", msg.data);
-          if (this._reject) this._reject(msg.data);
+          if (this.reject) this.reject(msg.data);
           break;
         case "stop":
           this.blob = msg.data;
           this.blobURL = URL.createObjectURL(msg.data);
           if (this.onStop) this.onStop();
-          if (this._resolve) this._resolve(this.blob);
+          if (this.resolve) this.resolve(this.blob);
           break;
         }
       }
@@ -269,17 +269,17 @@ class Recorder {
         this.encNode.onaudioprocess = null;
       }
 
-      this._resolve = resolve
-      this._reject = reject
+      this.resolve = resolve;
+      this.reject = reject;
     });
 
     if (this.worker) {
       this.worker.postMessage({type: "stop", data: null});
     } else {
-      return Promise.resolve(this.blob)
+      return Promise.resolve(this.blob);
     }
 
-    return resultP
+    return resultP;
   }
 }
 
@@ -477,7 +477,6 @@ class Form {
     this.tid = setTimeout(() => this.updateTime(), 300);
   }
 }
-
 
 let shown = false;
 


### PR DESCRIPTION
First off, excellent work with this module and writeup.  I've learned a lot from reading through both.

This PR makes it possible to use this module's awesome recording functionality without the bundled recorder UI.

I wanted to use just the recording functionality for [react-mp3-recorder](https://github.com/transitive-bullshit/react-mp3-recorder).

Instead of just exporting the `Form` class via a `record` function, it now exports `record` and `Recorder`, where the latter is just the core recording functionality without any UX.

Note that I've made sure the accompanying demo 100% still works with these changes. This refactor isn't mean to change the old functionality. I also tried to keep the changes minimal.

My recommendation for a follow-up PR would be to completely remove the UX from this module and just have it in the accompanying demo, as I doubt anyone will really want to use the Form UI as-is.  Either that or move the current UX into a separate module like `vmsg-dom` so the functionality is properly encapsulated from the presentation.

Thanks!