### PR TITLE
Export Recorder TS type from type declaration

### DIFF
--- a/vmsg.d.ts
+++ b/vmsg.d.ts
@@ -4,6 +4,17 @@ declare module "vmsg" {
     shimURL?: string;
     pitch?: number;
   }
+
+  export class Recorder {
+    constructor(opts: RecordOptions);
+    stopRecording(): Promise<Blob>;
+    initAudio(): Promise<void>;
+    initWorker(): Promise<void>;
+    init(): Promise<void>;
+    startRecording(): void;
+    close(): void;
+  }
+
   interface Exports {
     record: (opts?: RecordOptions) => Promise<Blob>;
   }


### PR DESCRIPTION
So `Recorder` can be easily exported then `import { Recorder } from 'vmsg';`

Fixes https://github.com/Kagami/vmsg/issues/20