### PR TITLE
Enable reuse of worker; Prevent instantiation of multiple workers

### DIFF
--- a/vmsg.js
+++ b/vmsg.js
@@ -221,7 +221,6 @@ export class Recorder {
   }
 
   initWorker() {
-    if (!this.stream) throw new Error("missing audio initialization");
     // https://stackoverflow.com/a/19201292
     const blob = new Blob(
       ["(", inlineWorker.toString(), ")()"],
@@ -283,6 +282,7 @@ export class Recorder {
     this.encNode.disconnect();
     this.encNode.onaudioprocess = null;
     this.stopTracks();
+    this.audioCtx.close();
     this.worker.postMessage({type: "stop", data: null});
     return new Promise((resolve, reject) => {
       this.resolve = resolve;


### PR DESCRIPTION
Worker initialization can be slow, so this allows early initialization of the worker as well as reuse between recordings. Currently, because calling Recorder.close() is the only defined interface for closing the AudioContext, all initialization has to be redone between recordings to prevent leaking of AudioContexts.